### PR TITLE
Migrate from eslint-config-synacor to eslint-config-preact

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,12 +10,14 @@
     "lint": "eslint src"
   },
   "eslintConfig": {
-    "extends": "eslint-config-synacor"
+    "extends": "preact"
   },
-  "eslintIgnore": ["build/*"],
+  "eslintIgnore": [
+    "build/*"
+  ],
   "devDependencies": {
-    "eslint": "^6.0.1",
-    "eslint-config-synacor": "^3.0.4",
+    "eslint": "^7.17.0",
+    "eslint-config-preact": "^1.1.3",
     "preact-cli": "^3.0.0",
     "sirv-cli": "^1.0.3"
   },

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -1,12 +1,9 @@
 import './style';
-import { Component } from 'preact';
 
-export default class App extends Component {
-	render() {
-		return (
-			<div>
-				<h1>Hello, World!</h1>
-			</div>
-		);
-	}
+export default function App() {
+	return (
+		<div>
+			<h1>Hello, World!</h1>
+		</div>
+	);
 }


### PR DESCRIPTION
This pull request close #14 by migrating the eslint configuration from eslint-config-synacor to eslint-config-preact.